### PR TITLE
Add option to use sis_course_id in api client methods

### DIFF
--- a/canvas_api_client/README.md
+++ b/canvas_api_client/README.md
@@ -1,7 +1,7 @@
 Canvas LMS API Client Library
 =============================
 
-version number: 0.0.1
+version number: 0.1.0
 author: Luc Cary
 
 Overview

--- a/canvas_api_client/canvas_api_client/interface.py
+++ b/canvas_api_client/canvas_api_client/interface.py
@@ -26,7 +26,8 @@ class CanvasAPIClient(metaclass=ABCMeta):
     @abstractmethod
     def get_course_users(
             self,
-            sis_course_id: str,
+            course_id: str,
+            is_sis_course_id: bool = False,
             params: RequestParams = None) -> Iterator[Response]:
         """
         Returns a generator of course enrollments for a given course.
@@ -38,6 +39,7 @@ class CanvasAPIClient(metaclass=ABCMeta):
             self,
             course_id: str,
             enrollment_id: str,
+            is_sis_course_id: bool = False,
             params: RequestParams = None) -> Response:
         """
         Deletes an enrollment for a given course.

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -127,12 +127,20 @@ class CanvasAPIv1(CanvasAPIClient):
                 headers=headers)
             yield response.json()
 
+    def _format_sis_course_id(self, course_id: str):
+        """
+        Returns request string for querying with a SIS course ID.
+        """
+        return "sis_course_id:{}".format(course_id)
+
     def get_account_courses(
             self,
             account_id: str,
             params: RequestParams = None) -> Iterator[Response]:
         """
         Returns a generator of courses for a given account from the v1 API.
+
+        https://canvas.instructure.com/doc/api/accounts.html#method.accounts.courses_api
         """
         endpoint = "accounts/{account_id}/courses".format(account_id=account_id)
 
@@ -140,13 +148,18 @@ class CanvasAPIv1(CanvasAPIClient):
 
     def get_course_users(
             self,
-            sis_course_id: str,
+            course_id: str,
+            is_sis_course_id: bool = False,
             params: RequestParams = None) -> Iterator[Response]:
         """
         Returns a generator of course enrollments for a given course from the v1 API.
+
+        https://canvas.instructure.com/doc/api/courses.html#method.courses.users
         """
-        endpoint = "courses/sis_course_id:{sis_course_id}/users".format(
-            sis_course_id=sis_course_id)
+        if is_sis_course_id:
+            course_id = self._format_sis_course_id(course_id)
+
+        endpoint = "courses/{}/users".format(course_id)
 
         return self._get_paginated(self._get_url(endpoint), params=params)
 
@@ -154,12 +167,16 @@ class CanvasAPIv1(CanvasAPIClient):
             self,
             course_id: str,
             enrollment_id: str,
+            is_sis_course_id: bool = False,
             params: RequestParams = None) -> Response:
         """
         Deletes an enrollment for a given course from the v1 API. Use with caution.
 
         https://canvas.instructure.com/doc/api/enrollments.html#method.enrollments_api.destroy
         """
+        if is_sis_course_id:
+            course_id = self._format_sis_course_id(course_id)
+
         endpoint = "courses/{course_id}/enrollments/{id}".format(
             course_id=course_id, id=enrollment_id)
 

--- a/canvas_api_client/requirements.txt
+++ b/canvas_api_client/requirements.txt
@@ -1,2 +1,2 @@
 # Library dependencies
-requests==2.13.0
+requests==2.18.1

--- a/canvas_api_client/setup.py
+++ b/canvas_api_client/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = '0.0.2'
+__version__ = '0.2.0'
 
 here = path.abspath(path.dirname(__file__))
 

--- a/canvas_api_client/setup.py
+++ b/canvas_api_client/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = '0.2.0'
+__version__ = '0.1.0'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
This option makes it possible to either use a sis_course_id or "normal" course_id when making API requests. The default is to use the "normal" Canvas API course_id, unless a flag is set. This requires a minor __version__ bump since there is a option change.