### PR TITLE
Extend the api client for usage with other requests library

### DIFF
--- a/canvas_api_client/README.md
+++ b/canvas_api_client/README.md
@@ -1,7 +1,7 @@
 Canvas LMS API Client Library
 =============================
 
-version number: 0.1.0
+version number: 0.2.0
 author: Luc Cary
 
 Overview

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -23,7 +23,7 @@ class CanvasAPIv1(CanvasAPIClient):
     def __init__(self,
                  api_url: str,
                  api_token: Optional[str] = None,
-                 requests_lib: Any = requests) -> None:
+                 requests_lib: Optional[Any] = requests) -> None:
         """
         Creates a canvas API client given a base URL for the API, an optional
         API token, and an optional requests library.

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import (Any, Dict, Iterator)
+from typing import (Any, Dict, Iterator, Optional)
 
 from canvas_api_client.errors import APIPaginationException
 from canvas_api_client.interface import CanvasAPIClient
@@ -20,28 +20,45 @@ class CanvasAPIv1(CanvasAPIClient):
     Create separate clients for other versions of the Canvas API.
     """
 
-    def __init__(self, api_url: str, api_token: str) -> None:
+    def __init__(self,
+                 api_url: str,
+                 api_token: Optional[str] = None,
+                 requests_lib: Any = requests) -> None:
+        """
+        Creates a canvas API client given a base URL for the API, an optional
+        API token, and an optional requests library.
+
+        The optional requests library should be either the python HTTP requests
+        library or the equivalent (e.g. a Requests-OAuthlib session object).
+        """
         self._api_url = api_url
         self._api_token = api_token
+        self._requests_lib = requests_lib
 
     def _get_url(self, endpoint: str) -> str:
+        """
+        Formats a Canvas API URL from a given endpoint.
+        """
         return "{base_url}{endpoint}".format(
             base_url=self._api_url, endpoint=endpoint)
 
     def _add_bearer_token(self, headers: Dict[str, Any]):
+        """
+        Adds the authentication bearer token. Only run this if the token exists.
+        """
         token_str = "Bearer {}".format(self._api_token)
         headers.update({'Authorization': token_str})
 
     def _send_request(self,
-                      url: str,
                       callback,
+                      url: str,
                       exit_on_error: bool = True,
                       headers: RequestHeaders = None,
                       params: RequestParams = None) -> Response:
         """
         Sends an API call to the Canvas server via callback method.
 
-        The callback should be a requests.<func> function.
+        The callback should be a requests.<func> function or the equivalent.
 
         Note: since raise_for_status() will raise an exception for error
         codes, the user is responsible for catching requests.exceptions.HTTPError
@@ -52,7 +69,8 @@ class CanvasAPIv1(CanvasAPIClient):
         if params is None:
             params = {}
 
-        self._add_bearer_token(headers)
+        if self._api_token is not None:
+            self._add_bearer_token(headers)
 
         response = callback(url, headers=headers, params=params)
         if not response.ok:
@@ -62,25 +80,29 @@ class CanvasAPIv1(CanvasAPIClient):
 
         return response
 
-    def _get(self,
-             url: str,
-             headers: RequestHeaders = None,
-             params: RequestParams = None) -> Response:
+    def _get(self, *args, **kwargs) -> Response:
         """
-        Sends a GET request to the Canvas v1 API.
+        Sends a GET request to the API.
         """
-        return self._send_request(
-            url, requests.get, headers=headers, params=params)
+        return self._send_request(self._requests_lib.get, *args, **kwargs)
 
-    def _delete(self,
-                url: str,
-                headers: RequestHeaders = None,
-                params: RequestParams = None) -> Response:
+    def _delete(self, *args, **kwargs) -> Response:
         """
-        Sends a DELETE request to the Canvas v1 API.
+        Sends a DELETE request to the API.
         """
-        return self._send_request(
-            url, requests.delete, headers=headers, params=params)
+        return self._send_request(self._requests_lib.delete, *args, **kwargs)
+
+    def _post(self, *args, **kwargs) -> Response:
+        """
+        Sends a POST request to the API.
+        """
+        return self._send_request(self._requests_lib.post, *args, **kwargs)
+
+    def _put(self, *args, **kwargs) -> Response:
+        """
+        Sends a PUT request to the API.
+        """
+        return self._send_request(self._requests_lib.put, *args, **kwargs)
 
     def _check_response_headers_for_pagination(self, response: Response):
         """

--- a/canvas_api_client/setup.py
+++ b/canvas_api_client/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 here = path.abspath(path.dirname(__file__))
 

--- a/canvas_api_client/tests/test_v1_client.py
+++ b/canvas_api_client/tests/test_v1_client.py
@@ -32,26 +32,27 @@ def _assert_request_called_once_with(mock_request_object, url, params=None):
 
 
 class TestCanvasAPIv1Client(TestCase):
-    @patch('canvas_api_client.v1_client.requests')
-    def setUp(self, mock_requests):
+
+    def setUp(self,):
+        self._mock_requests = MagicMock()
         self.test_client = CanvasAPIv1('https://foo.cc.columbia.edu/api/v1/',
-                                       'foo_token')
+                                       'foo_token',
+                                       requests_lib=self._mock_requests)
 
     # TODO(lcary): https://github.com/lcary/canvas-lms-tools/issues/3
     @skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
             "Skipping this test on Travis CI due to nonsensical error.")
     def test_send_request(self):
-        mock_requests = MagicMock()
         mock_response = MagicMock()
 
-        test_callback = mock_requests.get
+        test_callback = self._mock_requests.get
         test_callback.return_value = mock_response
 
         url = 'https://foo.cc.columbia.edu/api/v1/search'
 
         returned_response = self.test_client._send_request(
-            url,
             test_callback,
+            url,
             exit_on_error=True,
             headers={'foo': 'bar'},
             params={
@@ -67,21 +68,19 @@ class TestCanvasAPIv1Client(TestCase):
                 'x': 'y'
             })
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_get_paginated_exception(self, mock_requests):
+    def test_get_paginated_exception(self):
         mock_response = MagicMock()
         mock_response.headers = {}
         mock_response.json.return_value == {}
 
-        mock_requests.get.return_value = mock_response
+        self._mock_requests.get.return_value = mock_response
 
         url = 'https://foo.cc.columbia.edu/api/v1/search'
 
         with self.assertRaises(APIPaginationException):
             next(self.test_client._get_paginated(url))
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_get_paginated(self, mock_requests):
+    def test_get_paginated(self):
         url = 'https://foo.cc.columbia.edu/api/v1/search'
 
         mock_response_1 = get_mock_response_with_pagination(url)
@@ -89,7 +88,7 @@ class TestCanvasAPIv1Client(TestCase):
         mock_response_2 = MagicMock(headers={'link': url + 'page=2'})
         mock_response_2.json.return_value = {'value': 'second response'}
 
-        mock_requests.get.side_effect = [mock_response_1, mock_response_2]
+        self._mock_requests.get.side_effect = [mock_response_1, mock_response_2]
 
         generator = self.test_client._get_paginated(url)
         next_value = next(generator)
@@ -103,60 +102,54 @@ class TestCanvasAPIv1Client(TestCase):
         with self.assertRaises(StopIteration):
             next(generator)
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_get_account_courses(self, mock_requests):
+    def test_get_account_courses(self):
         url = 'https://foo.cc.columbia.edu/api/v1/accounts/1/courses'
 
         mock_response_1 = get_mock_response_with_pagination(url)
-        mock_requests.get.return_value = mock_response_1
+        self._mock_requests.get.return_value = mock_response_1
 
         next(self.test_client.get_account_courses('1'))
-        _assert_request_called_once_with(mock_requests.get, url)
+        _assert_request_called_once_with(self._mock_requests.get, url)
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_get_course_users(self, mock_requests):
+    def test_get_course_users(self):
         url = 'https://foo.cc.columbia.edu/api/v1/courses/57000/users'
 
         mock_response_1 = get_mock_response_with_pagination(url)
-        mock_requests.get.return_value = mock_response_1
+        self._mock_requests.get.return_value = mock_response_1
 
         next(self.test_client.get_course_users('57000'))
-        _assert_request_called_once_with(mock_requests.get, url)
+        _assert_request_called_once_with(self._mock_requests.get, url)
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_get_sis_course_users(self, mock_requests):
+    def test_get_sis_course_users(self):
         course = 'ASDFD5100_007_2018_1'
         url = 'https://foo.cc.columbia.edu/api/v1/courses/sis_course_id:{}/users'.format(
             course)
 
         mock_response_1 = get_mock_response_with_pagination(url)
-        mock_requests.get.return_value = mock_response_1
+        self._mock_requests.get.return_value = mock_response_1
 
         generator = self.test_client.get_course_users(
             course, is_sis_course_id=True)
         next(generator)
-        _assert_request_called_once_with(mock_requests.get, url)
+        _assert_request_called_once_with(self._mock_requests.get, url)
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_delete_enrollment(self, mock_requests):
+    def test_delete_enrollment(self):
         self.test_client.delete_enrollment(1234, 432432)
         url = 'https://foo.cc.columbia.edu/api/v1/courses/1234/enrollments/432432'
-        _assert_request_called_once_with(mock_requests.delete, url)
+        _assert_request_called_once_with(self._mock_requests.delete, url)
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_delete_enrollment_sis_course_id(self, mock_requests):
+    def test_delete_enrollment_sis_course_id(self):
         course = 'ASDFD5100_007_2018_2'
         self.test_client.delete_enrollment(
             course, 432432, is_sis_course_id=True)
         course_str = "sis_course_id:{}".format(course)
         url = 'https://foo.cc.columbia.edu/api/v1/courses/{}/enrollments/432432'.format(
             course_str)
-        _assert_request_called_once_with(mock_requests.delete, url)
+        _assert_request_called_once_with(self._mock_requests.delete, url)
 
-    @patch('canvas_api_client.v1_client.requests')
-    def test_delete_enrollment_delete_with_params(self, mock_requests):
+    def test_delete_enrollment_delete_with_params(self):
         params = {'task': 'delete'}
         self.test_client.delete_enrollment(1234, 432432, params=params)
         url = 'https://foo.cc.columbia.edu/api/v1/courses/1234/enrollments/432432'
         _assert_request_called_once_with(
-            mock_requests.delete, url, params=params)
+            self._mock_requests.delete, url, params=params)


### PR DESCRIPTION
This change extends the api client to use with requests libraries such as requests-oauthlib, which can be passed to the client object as a parameter upon creation. Additionally, I've added a number of other request types (e.g. PUT/POST) and refactored the client module accordingly.