### PR TITLE
Add methods to import SIS data into Canvas

### DIFF
--- a/canvas_api_client/canvas_api_client/interface.py
+++ b/canvas_api_client/canvas_api_client/interface.py
@@ -41,3 +41,12 @@ class CanvasAPIClient(metaclass=ABCMeta):
         Deletes an enrollment for a given course.
         """
         pass
+
+    @abstractmethod
+    def upload_sis_csv(self,
+                       csv_path: str,
+                       params: RequestParams = None) -> Response:
+        """
+        Uploads a CSV containing Student Information Services (SIS) changes.
+        """
+        pass

--- a/canvas_api_client/canvas_api_client/interface.py
+++ b/canvas_api_client/canvas_api_client/interface.py
@@ -43,10 +43,21 @@ class CanvasAPIClient(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def upload_sis_csv(self,
-                       csv_path: str,
-                       params: RequestParams = None) -> Response:
+    def import_sis_data(self,
+                        account_id: str,
+                        data_file: str,
+                        params: RequestParams = None) -> Response:
         """
         Uploads a CSV containing Student Information Services (SIS) changes.
+        """
+        pass
+
+    @abstractmethod
+    def get_sis_import_status(self,
+                              account_id: str,
+                              sis_import_id: str,
+                              params: RequestParams = None) -> Response:
+        """
+        Get the status of an already created SIS import.
         """
         pass

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -54,7 +54,8 @@ class CanvasAPIv1(CanvasAPIClient):
                       url: str,
                       exit_on_error: bool = True,
                       headers: RequestHeaders = None,
-                      params: RequestParams = None) -> Response:
+                      params: RequestParams = None,
+                      **kwargs) -> Response:
         """
         Sends an API call to the Canvas server via callback method.
 
@@ -72,7 +73,7 @@ class CanvasAPIv1(CanvasAPIClient):
         if self._api_token is not None:
             self._add_bearer_token(headers)
 
-        response = callback(url, headers=headers, params=params)
+        response = callback(url, headers=headers, params=params, **kwargs)
         if not response.ok:
             logger.debug('Error status code for url "{}"'.format(response.url))
         if exit_on_error:
@@ -203,7 +204,7 @@ class CanvasAPIv1(CanvasAPIClient):
         endpoint = 'accounts/{}/sis_imports'.format(account_id)
         url = self._get_url(endpoint)
         files = {'file': data_file}
-        return self._requests_lib.post(url, params=params, files=files)
+        return self._post(url, params=params, files=files)
 
     def get_sis_import_status(self,
                               account_id: str,

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -189,16 +189,30 @@ class CanvasAPIv1(CanvasAPIClient):
 
         return self._delete(self._get_url(endpoint), params=params)
 
-    def upload_sis_csv(self,
-                       csv_filepath: str,
-                       params: RequestParams = None) -> Response:
+    def import_sis_data(self,
+                        account_id: str,
+                        data_file: str,
+                        params: RequestParams = None) -> Response:
         """
+        Import SIS data into Canvas. Must be on a root account with SIS imports enabled.
+
+        https://canvas.instructure.com/doc/api/sis_imports.html#method.sis_imports_api.create
+
         https://canvas.instructure.com/doc/api/file.sis_csv.html
         """
-        endpoint = "accounts/1/sis_imports.json?import_type=instructure_csv"  # should import_type be in params?
-        params = {"override_sis_stickiness": "true"}  # make this overridable
-        headers = {
-            'Content_Type': 'multipart/form-data',
-            'Content': {'attachment': csv_path}
-        }
-        return self._post(self._get_url(endpoint), params=params, headers=headers)
+        endpoint = 'accounts/{}/sis_imports'.format(account_id)
+        url = self._get_url(endpoint)
+        files = {'file': data_file}
+        return self._requests_lib.post(url, params=params, files=files)
+
+    def get_sis_import_status(self,
+                              account_id: str,
+                              sis_import_id: str,
+                              params: RequestParams = None) -> Response:
+        """
+        Get the status of an already created SIS import.
+
+        https://canvas.instructure.com/doc/api/sis_imports.html#method.sis_imports_api.show
+        """
+        endpoint = 'accounts/{}/sis_imports/{}'.format(account_id, sis_import_id)
+        return self._get(self._get_url(endpoint), params=params)

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -203,8 +203,9 @@ class CanvasAPIv1(CanvasAPIClient):
         """
         endpoint = 'accounts/{}/sis_imports'.format(account_id)
         url = self._get_url(endpoint)
-        files = {'file': data_file}
-        return self._post(url, params=params, files=files)
+        with open(data_file, 'rb') as f:
+            files = {'attachment': f}
+            return self._post(url, params=params, files=files)
 
     def get_sis_import_status(self,
                               account_id: str,

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -188,3 +188,17 @@ class CanvasAPIv1(CanvasAPIClient):
             course_id=course_id, id=enrollment_id)
 
         return self._delete(self._get_url(endpoint), params=params)
+
+    def upload_sis_csv(self,
+                       csv_filepath: str,
+                       params: RequestParams = None) -> Response:
+        """
+        https://canvas.instructure.com/doc/api/file.sis_csv.html
+        """
+        endpoint = "accounts/1/sis_imports.json?import_type=instructure_csv"  # should import_type be in params?
+        params = {"override_sis_stickiness": "true"}  # make this overridable
+        headers = {
+            'Content_Type': 'multipart/form-data',
+            'Content': {'attachment': csv_path}
+        }
+        return self._post(self._get_url(endpoint), params=params, headers=headers)


### PR DESCRIPTION
The new methods in this merge request add the ability for the api client to upload SIS data and query the status of a specific SIS import.