### PR TITLE
Add new method to query roles api

### DIFF
--- a/canvas_api_client/canvas_api_client/interface.py
+++ b/canvas_api_client/canvas_api_client/interface.py
@@ -61,3 +61,13 @@ class CanvasAPIClient(metaclass=ABCMeta):
         Get the status of an already created SIS import.
         """
         pass
+
+    @abstractmethod
+    def get_account_roles(self,
+                          account_id: str,
+                          is_sis_account_id: bool = False,
+                          params: RequestParams = None) -> Response:
+        """
+        Get the roles for an existing account.
+        """
+        pass

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -142,6 +142,12 @@ class CanvasAPIv1(CanvasAPIClient):
         """
         return "sis_course_id:{}".format(course_id)
 
+    def _format_sis_account_id(self, account_id: str):
+        """
+        Returns request string for querying with a SIS account ID.
+        """
+        return "sis_account_id:{}".format(account_id)
+
     def get_account_courses(self,
                             account_id: str,
                             params: RequestParams = None
@@ -218,3 +224,17 @@ class CanvasAPIv1(CanvasAPIClient):
         """
         endpoint = 'accounts/{}/sis_imports/{}'.format(account_id, sis_import_id)
         return self._get(self._get_url(endpoint), params=params)
+
+    def get_account_roles(self,
+                          account_id: str,
+                          is_sis_account_id: bool = False,
+                          params: RequestParams = None) -> Response:
+        """
+        Get the roles for an existing account.
+
+        https://canvas.instructure.com/doc/api/roles.html#method.role_overrides.api_index
+        """
+        if is_sis_account_id:
+            account_id = self._format_sis_account_id(account_id)
+        endpoint = 'accounts/{}/roles'.format(account_id)
+        return self._get_paginated(self._get_url(endpoint), params=params)

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -237,4 +237,4 @@ class CanvasAPIv1(CanvasAPIClient):
         if is_sis_account_id:
             account_id = self._format_sis_account_id(account_id)
         endpoint = 'accounts/{}/roles'.format(account_id)
-        return self._get_paginated(self._get_url(endpoint), params=params)
+        return self._get(self._get_url(endpoint), params=params)

--- a/canvas_api_client/setup.py
+++ b/canvas_api_client/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 here = path.abspath(path.dirname(__file__))
 

--- a/canvas_api_client/tests/test_v1_client.py
+++ b/canvas_api_client/tests/test_v1_client.py
@@ -175,3 +175,13 @@ class TestCanvasAPIv1Client(TestCase):
         self.test_client.get_sis_import_status('1', '14809')
         url = 'https://foo.cc.columbia.edu/api/v1/accounts/1/sis_imports/14809'
         _assert_request_called_once_with(self._mock_requests.get, url)
+
+    def test_get_account_roles(self):
+        self.test_client.get_account_roles('1')
+        url = 'https://foo.cc.columbia.edu/api/v1/accounts/1/roles'
+        _assert_request_called_once_with(self._mock_requests.get, url)
+
+    def test_get_account_roles_sis(self):
+        self.test_client.get_account_roles('ASDF', is_sis_account_id=True)
+        url = 'https://foo.cc.columbia.edu/api/v1/accounts/sis_account_id:ASDF/roles'
+        _assert_request_called_once_with(self._mock_requests.get, url)


### PR DESCRIPTION
This patch adds a new method to the api client that allows us to query the roles api.

This is necessary for the ldap enrollments sync currently WIP internally.