### PR TITLE
Add mypy tox integration and increase test coverage

### DIFF
--- a/canvas_api_client/canvas_api_client/interface.py
+++ b/canvas_api_client/canvas_api_client/interface.py
@@ -1,7 +1,9 @@
 from abc import (ABCMeta, abstractmethod)
 from typing import (Iterator, List, Optional)
 
-from canvas_api_client.types import (RequestParams, Response)
+from canvas_api_client.types import RequestParams
+
+from requests import Response
 
 
 class CanvasAPIClient(metaclass=ABCMeta):
@@ -19,7 +21,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Returns a generator of courses for a given account.
         """
-        pass
 
     @abstractmethod
     def get_course_users(self,
@@ -29,7 +30,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Returns a generator of course enrollments for a given course.
         """
-        pass
 
     @abstractmethod
     def delete_enrollment(self,
@@ -40,7 +40,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Deletes an enrollment for a given course.
         """
-        pass
 
     @abstractmethod
     def put_page(self,
@@ -56,7 +55,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Creates a new wiki page for a given course
         """
-        pass
 
     @abstractmethod
     def import_sis_data(self,
@@ -66,7 +64,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Uploads a CSV containing Student Information Services (SIS) changes.
         """
-        pass
 
     @abstractmethod
     def get_sis_import_status(self,
@@ -76,7 +73,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Get the status of an already created SIS import.
         """
-        pass
 
     @abstractmethod
     def get_account_roles(self,
@@ -86,7 +82,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Get the roles for an existing account.
         """
-        pass
 
     @abstractmethod
     def update_course(self,
@@ -96,7 +91,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Updates a given course.
         """
-        pass
 
     @abstractmethod
     def publish_course(self,
@@ -106,7 +100,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Publishes a given course.
         """
-        pass
 
     @abstractmethod
     def associate_courses_to_blueprint(self,
@@ -117,7 +110,6 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Associates courses to a given blueprint course.
         """
-        pass
 
     @abstractmethod
     def get_account_blueprint_courses(self,
@@ -127,4 +119,3 @@ class CanvasAPIClient(metaclass=ABCMeta):
         """
         Get all the blueprint courses in a given account
         """
-        pass

--- a/canvas_api_client/canvas_api_client/types.py
+++ b/canvas_api_client/canvas_api_client/types.py
@@ -1,6 +1,5 @@
 from typing import (Any, Dict, Optional)
 
 # Request types:
-RequestHeaders = Optional[Dict[str, str]]
-RequestParams = Optional[Dict[str, str]]
-Response = Any
+RequestHeaders = Optional[Dict[str, Any]]
+RequestParams = Optional[Dict[str, Any]]

--- a/canvas_api_client/canvas_api_client/v1_client.py
+++ b/canvas_api_client/canvas_api_client/v1_client.py
@@ -3,9 +3,10 @@ from typing import (Any, Dict, Iterator, List, Optional)
 
 from canvas_api_client.errors import APIPaginationException
 from canvas_api_client.interface import CanvasAPIClient
-from canvas_api_client.types import (RequestHeaders, RequestParams, Response)
+from canvas_api_client.types import (RequestHeaders, RequestParams)
 
 import requests
+from requests import Response
 
 logger = logging.getLogger()
 
@@ -85,25 +86,29 @@ class CanvasAPIv1(CanvasAPIClient):
         """
         Sends a GET request to the API.
         """
-        return self._send_request(self._requests_lib.get, *args, **kwargs)
+        return self._send_request(
+            self._requests_lib.get, *args, **kwargs)  # type: ignore
 
     def _delete(self, *args, **kwargs) -> Response:
         """
         Sends a DELETE request to the API.
         """
-        return self._send_request(self._requests_lib.delete, *args, **kwargs)
+        return self._send_request(
+            self._requests_lib.delete, *args, **kwargs)  # type: ignore
 
     def _post(self, *args, **kwargs) -> Response:
         """
         Sends a POST request to the API.
         """
-        return self._send_request(self._requests_lib.post, *args, **kwargs)
+        return self._send_request(
+            self._requests_lib.post, *args, **kwargs)  # type: ignore
 
     def _put(self, *args, **kwargs) -> Response:
         """
         Sends a PUT request to the API.
         """
-        return self._send_request(self._requests_lib.put, *args, **kwargs)
+        return self._send_request(
+            self._requests_lib.put, *args, **kwargs)  # type: ignore
 
     def _check_response_headers_for_pagination(self, response: Response):
         """

--- a/canvas_api_client/setup.py
+++ b/canvas_api_client/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = '0.2.8'
+__version__ = '0.2.9'
 
 here = path.abspath(path.dirname(__file__))
 

--- a/canvas_api_client/tox.ini
+++ b/canvas_api_client/tox.ini
@@ -6,9 +6,11 @@ passenv = TRAVIS
 deps =
     -r{toxinidir}/requirements.txt
     flake8
+    mypy
     pytest
 commands =
     flake8 canvas_api_client
+    mypy canvas_api_client
     py.test
 
 [testenv:cov]


### PR DESCRIPTION
Being lazy and bundling changes:
- This pull request does some general housekeeping work for the project. It adds mypy checks to the default tox testing environment. To do this, I added a few fixes for mypy. 
- While here, I increased the test coverage by removing the unnecessary `pass` statements in the interface, and adding a missing unit test. 
- Additionally, I realized https://github.com/lcary/canvas-lms-tools/issues/3 can be fixed easily, so I fixed it.